### PR TITLE
[TASK] Add extension key configuration to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -50,6 +50,7 @@
   "extra": {
     "typo3/cms": {
       "cms-package-dir": "{$vendor-dir}/typo3/cms",
+      "extension-key": "reporter",
       "web-dir": ".Build/Web"
     }
   }


### PR DESCRIPTION
According to https://docs.typo3.org/m/typo3/reference-coreapi/master/en-us/ExtensionArchitecture/ComposerJson/Index.html#extra) TYPO3 extensions should have an "extra" section in composer.json explicitly defining their TYPO3 extension key.

This PR adds the appropriate configuration to the composer.json file.